### PR TITLE
make tau optional in evaluate! for mGGA to accept mGGA functionals depend only on laplacian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Libxc"
 uuid = "66e17ffc-8502-11e9-23b5-c9248d0eb96d"
 authors = ["Jason Eu <morty.yu@yahoo.com>", "Michael F. Herbst <info@michael-herbst.com>"]
-version = "0.3.21"
+version = "0.3.22"
 
 [deps]
 Libxc_GPU_jll = "25af9330-9b41-55d4-a324-1a83c0a0a1ac"

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -173,7 +173,7 @@ end
 
 
 function evaluate!(func::Functional, ::Union{Val{:mgga},Val{:hyb_mgga}}, rho::Array{Float64};
-                   sigma::Array{Float64}, tau::Array{Float64}, lapl::OptArray=C_NULL,
+                   sigma::Array{Float64}, tau::OptArray=C_NULL, lapl::OptArray=C_NULL,
                    zk::OptArray=C_NULL,
                    vrho::OptArray=C_NULL,
                    vsigma::OptArray=C_NULL,
@@ -244,6 +244,9 @@ function evaluate!(func::Functional, ::Union{Val{:mgga},Val{:hyb_mgga}}, rho::Ar
                    v4lapl2tau2::OptArray=C_NULL,
                    v4lapltau3::OptArray=C_NULL,
                    v4tau4::OptArray=C_NULL)
+    # check if the mGGA functional needs tau or lapl
+    needs_tau(func) && tau === C_NULL && throw(ArgumentError("Functional $(func.identifier) requires tau"))
+    needs_laplacian(func) && lapl === C_NULL && throw(ArgumentError("Functional $(func.identifier) requires lapl"))
     np = Int(length(rho) / func.spin_dimensions.rho)
     xc_mgga(func.pointer_, np, rho, sigma, lapl, tau, zk, vrho, vsigma, vlapl, vtau,
             v2rho2, v2rhosigma, v2rholapl, v2rhotau, v2sigma2, v2sigmalapl,

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -245,7 +245,7 @@ function evaluate!(func::Functional, ::Union{Val{:mgga},Val{:hyb_mgga}}, rho::Ar
                    v4lapltau3::OptArray=C_NULL,
                    v4tau4::OptArray=C_NULL)
     # check if the mGGA functional needs tau or lapl
-    needs_tau(func) && tau === C_NULL && throw(ArgumentError("Functional $(func.identifier) requires tau"))
+    needs_tau(func)       && tau  === C_NULL && throw(ArgumentError("Functional $(func.identifier) requires tau"))
     needs_laplacian(func) && lapl === C_NULL && throw(ArgumentError("Functional $(func.identifier) requires lapl"))
     np = Int(length(rho) / func.spin_dimensions.rho)
     xc_mgga(func.pointer_, np, rho, sigma, lapl, tau, zk, vrho, vsigma, vlapl, vtau,


### PR DESCRIPTION
Meta-GGA kinetic functionals in Libxc require the Laplacian. The current implementation is asking for tau and sets lapl, which is required for these functionals, to C_NULL. This leads to a segmentation fault error. I made tau optional too and added two checks afterwards using the already defined functions needs_tau and needs_laplacian