### PR TITLE
Update CUDA version check to latest Libxc_GPU_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Libxc"
 uuid = "66e17ffc-8502-11e9-23b5-c9248d0eb96d"
 authors = ["Jason Eu <morty.yu@yahoo.com>", "Michael F. Herbst <info@michael-herbst.com>"]
-version = "0.3.25"
+version = "0.3.26"
 
 [deps]
 Libxc_GPU_jll = "25af9330-9b41-55d4-a324-1a83c0a0a1ac"

--- a/ext/LibxcCudaExt.jl
+++ b/ext/LibxcCudaExt.jl
@@ -5,8 +5,8 @@ using CUDA
 
 function __init__()
     if CUDA.functional()
-        if !Libxc_GPU_jll.is_available() && CUDA.runtime_version() > v"13.1"
-            @warn("Libxc_GPU_jll currently not available for CUDA > v13.1." *
+        if !Libxc_GPU_jll.is_available() && CUDA.runtime_version() > v"13.3"
+            @warn("Libxc_GPU_jll currently not available for CUDA > v13.3." *
                   "Please use a lower version of CUDA for support." *
                   """(e.g. `CUDA.set_runtime_version!(v"12.8")`)""")
         end


### PR DESCRIPTION
Binaries are now available for CUDA `v13.2` and `v13.3` (https://github.com/JuliaPackaging/Yggdrasil/pull/14036#event-27155983707).